### PR TITLE
fix: set selected environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ A CLI for maintenance-utils.
 `bridge pause` - pauses all bridge instances across the selected network
 `bridge unpause` - unpauses all bridge instances across the selected network
 `bridge retry` - retries a failed transaction
+`bridge test-routes` - test transfers for all defined domains and resources. If you want to test just specific routes, define domains in sharedConfig.json file.
 `relayer top-up` - tops upp all relayers balances that are under the `nativeTokenMinBalance`, the top amount can be adjusted with `RELAYER_TOP_UP_MULTIPLIER` env variable

--- a/sharedConfig.json
+++ b/sharedConfig.json
@@ -2,51 +2,83 @@
   "domains": [
     {
       "id": 1,
-      "chainId": 5,
+      "chainId": 1,
       "name": "ethereum",
       "type": "evm",
-      "bridge": "0x5cEA5130c49dCd262B9482E0A76eCE8b23Ae45Df",
+      "bridge": "0x4D878E8Fb90178588Cda4cf1DCcdC9a6d2757089",
       "handlers": [
         {
           "type": "erc20",
-          "address": "0x7461F7023F017257039197615a2667dFEb7F21Cd"
-        },
-        {
-          "type": "erc721",
-          "address": "0xe938a6fB2D3a8B836Bec896e38919Ec42FB7089B"
-        },
-        {
-          "type": "permissionedGeneric",
-          "address": "0x25d2C5Fe1aa70c593e2090B3Dcecc5849676a303"
+          "address": "0xC832588193cd5ED2185daDA4A531e0B26eC5B830"
         },
         {
           "type": "permissionlessGeneric",
-          "address": "0xd938c1053f834B2B6Ad7a7782d60aa00fBb49e46"
+          "address": "0x31282123E7bcd947e2c1Bc364d564839574fAdCD"
         }
       ],
       "nativeTokenSymbol": "eth",
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 8987145,
-      "feeRouter": "0x860B8a9b84Be8f2bF98d6455699cae5dcecCf43a",
+      "startBlock": 17471012,
+      "feeRouter": "0x1d34808907607FA82Fa1b51F5fBA5Ff5a3Fa90cF",
       "feeHandlers": [
         {
-          "address": "0x4828Fb7b41D5B4AC8428de2bbD0cb616Cd494973",
+          "address": "0x9f9778DA7c1D0AbE148314d6C1EA6E0A93C151C7",
           "type": "basic"
+        }
+      ],
+      "resources": [
+        {
+          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "type": "fungible",
+          "address": "0x6c5bA91642F10282b576d91922Ae6448C9d52f4E",
+          "symbol": "PHA",
+          "decimals": 18
         },
         {
-          "address": "0x4828Fb7b41D5B4AC8428de2bbD0cb616Cd494973",
-          "type": "percentage"
+          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "type": "permissionlessGeneric",
+          "address": "",
+          "symbol": "",
+          "decimals": 18
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "chainId": 100,
+      "name": "gnosis",
+      "type": "evm",
+      "bridge": "0x5FdC38c9b32909CcfF4629ffBFe5394852584C59",
+      "handlers": [
+        {
+          "type": "erc20",
+          "address": "0x89b835B4b01E29C9464860189a394297913fD65B"
+        },
+        {
+          "type": "permissionlessGeneric",
+          "address": "0xde57DEfEe28F0F59C5Ad3B7116B3E98d257f6f27"
+        }
+      ],
+      "nativeTokenSymbol": "XDAI",
+      "nativeTokenFullName": "xDai",
+      "nativeTokenDecimals": 18,
+      "blockConfirmations": 5,
+      "startBlock": 31074851,
+      "feeRouter": "0xbb2bf03eD554571EFe9BEE2b46dFdc7e44c157e4",
+      "feeHandlers": [
+        {
+          "address": "0xDAC861f54368cD917f6dbEb93FF90727B2c37cB2",
+          "type": "basic"
         }
       ],
       "resources": [
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "type": "fungible",
-          "address": "0x3D151A97A446C9ea6893038e7C0db73466f3f3af",
-          "burnable": true,
-          "symbol": "ERC20TST",
+          "type": "permissionlessGeneric",
+          "address": "",
+          "symbol": "",
           "decimals": 18
         }
       ]

--- a/src/extensions/sharedConfig.ts
+++ b/src/extensions/sharedConfig.ts
@@ -14,31 +14,32 @@ module.exports = (toolbox: GluegunToolbox) => {
       choices: Object.keys(Environment),
     })
 
-    // if local environment selected, configure shared-config through sharedConfig.json
-    if(result.env.toLowerCase() == Environment.LOCAL) {
+    // if domains are configured in local sharedConfig.json file, use local sharedConfig data
       toolbox.env = result.env
-      return filesystem.read(
+      const rawConfig =  filesystem.read(
         'sharedConfig.json',
         'json'
       ) as RawConfig
-    }
 
-    const api = http.create({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      baseURL: ConfigUrl[result.env],
-    })
-    ConfigUrl[result.env]
-    /**
-     * This is an empty string because we don't have a unique base url
-     * across all environments. To avoid excess logic
-     * the whole shared config url is passed as base url.
-     */
-    const { ok, data } = await api.get('')
-    if (!ok) {
-      throw new Error('Failed to fetch shared config.')
+    if(rawConfig.domains.length) {
+      return rawConfig
+    } else {
+      const api = http.create({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        baseURL: ConfigUrl[result.env],
+      })
+      ConfigUrl[result.env]
+      /**
+       * This is an empty string because we don't have a unique base url
+       * across all environments. To avoid excess logic
+       * the whole shared config url is passed as base url.
+       */
+      const { ok, data } = await api.get('')
+      if (!ok) {
+        throw new Error('Failed to fetch shared config.')
+      }
+      return data as RawConfig
     }
-    toolbox.env = result.env
-    return data as RawConfig
   }
   toolbox.sharedConfig = { fetchSharedConfig }
 }

--- a/src/extensions/sharedConfig.ts
+++ b/src/extensions/sharedConfig.ts
@@ -16,6 +16,7 @@ module.exports = (toolbox: GluegunToolbox) => {
 
     // if local environment selected, configure shared-config through sharedConfig.json
     if(result.env.toLowerCase() == Environment.LOCAL) {
+      toolbox.env = result.env
       return filesystem.read(
         'sharedConfig.json',
         'json'


### PR DESCRIPTION
### Changed behavior of the test-routes script
When local sharedConfiguration is configured, by default use local sharedConfiguration
if the local sharedConfiguration is not set, fetch sharedConfig from a server for the environment that is chosen through CLI prompt.
### Reasoning
this change was needed because the sygma-SDK is not able to load custom sharedConfiguration, even if we choose LOCAL environment. Instead, the SDK uses local hardcoded sharedConfig. Effectively SDK can be used only for sygma DEVNET/TESNET/MAINNET environment.